### PR TITLE
Fixed listFiles() to include all file metadata & application keys implementation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -321,7 +321,17 @@ class Client
             foreach ($response['files'] as $file) {
                 // if we have a file name set, only retrieve information if the file name matches
                 if (!$fileName || ($fileName === $file['fileName'])) {
-                    $files[] = new File($file['fileId'], $file['fileName'], null, $file['contentLength']);
+                    $files[] = new File(
+											$file['fileId'],
+											$file['fileName'],
+											$file['contentSha1'],
+											$file['contentLength'],
+											$file['contentType'],
+											$file['fileInfo'],
+											$file['bucketId'],
+											$file['action'],
+											$file['uploadedTimestamp']
+										);
                 }
             }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -471,17 +471,23 @@ class Client
      * Maps the provided bucket name to the appropriate bucket ID.
      *
      * @param $name
-     * @return null
+     * @return mixed
      */
     protected function getBucketIdFromName($name)
     {
-        $buckets = $this->listBuckets();
+        $response = $this->client->request('POST', $this->apiUrl.'/b2_list_buckets', [
+						'headers' => [
+								'Authorization' => $this->authToken,
+						],
+						'json' => [
+								'accountId'  => $this->accountId,
+								'bucketName' => $name
+						]
+				]);
 
-        foreach ($buckets as $bucket) {
-            if ($bucket->getName() === $name) {
-                return $bucket->getId();
-            }
-        }
+				if (!empty($response['buckets'])) {
+					return $response['buckets'][0]['bucketId'];
+				}
 
         return null;
     }
@@ -490,17 +496,23 @@ class Client
      * Maps the provided bucket ID to the appropriate bucket name.
      *
      * @param $id
-     * @return null
+     * @return mixed
      */
     protected function getBucketNameFromId($id)
     {
-        $buckets = $this->listBuckets();
+				$response = $this->client->request('POST', $this->apiUrl.'/b2_list_buckets', [
+						'headers' => [
+								'Authorization' => $this->authToken,
+						],
+						'json' => [
+								'accountId'  => $this->accountId,
+								'bucketId' => $id
+						]
+				]);
 
-        foreach ($buckets as $bucket) {
-            if ($bucket->getId() === $id) {
-                return $bucket->getName();
-            }
-        }
+				if (!empty($response['buckets'])) {
+					return $response['buckets'][0]['bucketName'];
+				}
 
         return null;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -330,7 +330,7 @@ class Client
 											$file['fileInfo'],
 											$file['bucketId'],
 											$file['action'],
-											$file['uploadedTimestamp']
+											$file['uploadTimestamp']
 										);
                 }
             }


### PR DESCRIPTION
The listFiles() method does not instantiate File objects with all of the metadata returned from the B2 API. Including the rest of the metadata reduces the number of API calls necessary for getting file information.